### PR TITLE
resin.env: source it with explicitly relative path

### DIFF
--- a/disable-rolling-release-on-fleet.sh
+++ b/disable-rolling-release-on-fleet.sh
@@ -5,7 +5,7 @@
 ############################################################################################################
 
 # Bring our resin Token, URL, etc from resin.env file
-source resin.env
+source ./resin.env
 
 # Patch call to set "should_track_latest_release"  to false
 echo "Disabling rolling release tracking for APP == $APP_ID"

--- a/enable-rolling-release-on-fleet.sh
+++ b/enable-rolling-release-on-fleet.sh
@@ -3,7 +3,7 @@
 # Note that you will need to either set the Application Commit to the latest using ./set-fleet-commit-hash.sh
 # or do another git push and the devices will update to that new build.
 
-source resin.env
+source ./resin.env
 echo "enabling rolling release tracking for APP == $APP_ID"
 curl -X PATCH "https://api.$BASE_URL/v2/application($APP_ID)" -H "Authorization: Bearer $authToken" -H "Content-Type: application/json" --data-binary '{"should_track_latest_release":true}'
 

--- a/get-build-id.sh
+++ b/get-build-id.sh
@@ -1,6 +1,6 @@
 ## This script returns the `build_id` for a specific commit on a resin.io application.
 ## usage: ./get-build-id.sh <FULL_COMMIT_HASH>
 COMMIT_HASH=$1
-source resin.env
+source ./resin.env
 
 curl "https://api.$BASE_URL/v2/build?\$select=id,commit_hash&\$filter=application%20eq%20$APP_ID%20and%20commit_hash%20eq%20'$COMMIT_HASH'" -H "Authorization: Bearer $authToken" | jq '.d[0].id' 

--- a/set-device-to-a-build.sh
+++ b/set-device-to-a-build.sh
@@ -1,6 +1,6 @@
 ## This script sets a single device to a specific build of a commit.
 ## Usage: ./set-device-to-a-build.sh <DEVICE_ID> <FULL_COMMIT_HASH>
-source resin.env
+source ./resin.env
 DEVICE_ID=$1
 COMMIT=$2
 BUILD_ID=$(./get-build-id.sh $COMMIT)

--- a/set-fleet-commit-hash.sh
+++ b/set-fleet-commit-hash.sh
@@ -1,8 +1,8 @@
 ## This script sets the fleet wide commit hash to a specified value.
-## It is usually used after one has disabled rolling releases and allows one 
+## It is usually used after one has disabled rolling releases and allows one
 ## to set an entire fleet to any specific build in their list of builds for an App.
 
-source resin.env
+source ./resin.env
 COMMIT_HASH=$1
 echo "setting APP: $APP_ID to COMMIT == $COMMIT_HASH"
 curl -X PATCH "https://api.$BASE_URL/v2/application($APP_ID)" -H "Authorization: Bearer $authToken" -H "Content-Type: application/json" --data-binary '{"commit":"'$COMMIT_HASH'"}'

--- a/update-test-group.sh
+++ b/update-test-group.sh
@@ -3,7 +3,7 @@
 # these devices will then update to whatever commit is supplied as arg $1
 
 COMMIT_HASH=$1
-source resin.env
+source ./resin.env
 
 device_list=$(curl -X GET -H "Authorization: Bearer  $authToken" -H "Content-Type: application/json" "https://api.$BASE_URL/v2/device?\$expand=device_environment_variable%2Capplication&\$filter=application/app_name%20eq%20%27$APP_NAME%27%20and%20device_environment_variable/env_var_name%20eq%20%27TEST%27&\$select=id" | jq '.d[] | .id')
 


### PR DESCRIPTION
The previous form worked in `bash` but not in `zsh`, this latter was complaining about not finding the file. Once this change, both shells work fine.

Alternatively, could specify `bash` in all the scripts as `#!/usr/bin/bash`, that way all the scripts will be running through bash instead of the user's own shell. But I guess this PR's version is more portable.
