### PR TITLE
Check auth & url configuration before each script, and add shebangs

### DIFF
--- a/check-configuration.sh
+++ b/check-configuration.sh
@@ -1,0 +1,9 @@
+# This file checks that the settings in resin.env are loaded and authenticating correctly
+
+source ./resin.env
+response=$(curl --silent "https://api.$BASE_URL/user/v1/whoami" -H "Authorization: Bearer $authToken")
+
+if [ $? -ne 0 ]; then
+    echo "Could not authenticate to '$BASE_URL', please check your configuration"
+    exit 1
+fi

--- a/check-configuration.sh
+++ b/check-configuration.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This file checks that the settings in resin.env are loaded and authenticating correctly
 
 source ./resin.env

--- a/disable-rolling-release-on-fleet.sh
+++ b/disable-rolling-release-on-fleet.sh
@@ -4,6 +4,8 @@
 # script to lock to a specific commit from your list of builds in your "Build logs" page on the dashboard.
 ############################################################################################################
 
+./check-configuration.sh || exit 1
+
 # Bring our resin Token, URL, etc from resin.env file
 source ./resin.env
 

--- a/disable-rolling-release-on-fleet.sh
+++ b/disable-rolling-release-on-fleet.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ######################## Disable Rolling Release for an App ################################################
 # This script stops the automatic updating of devices in an App whenever a new build is triggered.
 # You will also need to set a specific Application commit to lock the App to, use the "set-fleet-commit-hash.sh"

--- a/enable-rolling-release-on-fleet.sh
+++ b/enable-rolling-release-on-fleet.sh
@@ -3,6 +3,8 @@
 # Note that you will need to either set the Application Commit to the latest using ./set-fleet-commit-hash.sh
 # or do another git push and the devices will update to that new build.
 
+./check-configuration.sh || exit 1
+
 source ./resin.env
 echo "enabling rolling release tracking for APP == $APP_ID"
 curl -X PATCH "https://api.$BASE_URL/v2/application($APP_ID)" -H "Authorization: Bearer $authToken" -H "Content-Type: application/json" --data-binary '{"should_track_latest_release":true}'

--- a/enable-rolling-release-on-fleet.sh
+++ b/enable-rolling-release-on-fleet.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This reverses the action in ./disable-rolling-release-on-fleet.sh
 # and causes all the devices to again start tracking the latest build.
 # Note that you will need to either set the Application Commit to the latest using ./set-fleet-commit-hash.sh

--- a/get-build-id.sh
+++ b/get-build-id.sh
@@ -1,5 +1,8 @@
 ## This script returns the `build_id` for a specific commit on a resin.io application.
 ## usage: ./get-build-id.sh <FULL_COMMIT_HASH>
+
+./check-configuration.sh || exit 1
+
 COMMIT_HASH=$1
 source ./resin.env
 

--- a/get-build-id.sh
+++ b/get-build-id.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ## This script returns the `build_id` for a specific commit on a resin.io application.
 ## usage: ./get-build-id.sh <FULL_COMMIT_HASH>
 

--- a/get-device-id.sh
+++ b/get-device-id.sh
@@ -1,5 +1,8 @@
 ## This script returns the `device_id` for a specific device on a resin.io application.
 ## usage: ./get-device-id.sh <DEVICE_UUID>
+
+./check-configuration.sh || exit 1
+
 DEVICE_UUID=$1
 source ./resin.env
 

--- a/get-device-id.sh
+++ b/get-device-id.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ## This script returns the `device_id` for a specific device on a resin.io application.
 ## usage: ./get-device-id.sh <DEVICE_UUID>
 

--- a/set-device-to-a-build.sh
+++ b/set-device-to-a-build.sh
@@ -3,6 +3,8 @@
 ## Usage: ./set-device-to-a-build.sh <DEVICE_UUID> <FULL_COMMIT_HASH>
 ## Usage: ./set-device-to-a-build.sh <DEVICE_UUID>
 
+./check-configuration.sh || exit 1
+
 source ./resin.env
 DEVICE_UUID=$1
 DEVICE_ID=$(./get-device-id.sh $DEVICE_UUID)

--- a/set-device-to-a-build.sh
+++ b/set-device-to-a-build.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ## This script sets a single device to a specific build of a commit.
 ## To set a device back to the most recent release, run this script without a commit hash parameter.
 ## Usage: ./set-device-to-a-build.sh <DEVICE_UUID> <FULL_COMMIT_HASH>

--- a/set-fleet-commit-hash.sh
+++ b/set-fleet-commit-hash.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ## This script sets the fleet wide commit hash to a specified value.
 ## It is usually used after one has disabled rolling releases and allows one
 ## to set an entire fleet to any specific build in their list of builds for an App.

--- a/set-fleet-commit-hash.sh
+++ b/set-fleet-commit-hash.sh
@@ -2,6 +2,8 @@
 ## It is usually used after one has disabled rolling releases and allows one
 ## to set an entire fleet to any specific build in their list of builds for an App.
 
+./check-configuration.sh || exit 1
+
 source ./resin.env
 COMMIT_HASH=$1
 echo "setting APP: $APP_ID to COMMIT == $COMMIT_HASH"

--- a/update-test-group.sh
+++ b/update-test-group.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This script sets a group of devices to a specific commit,
 # currently it will look for devices in an app that have an environment variable called "TEST"
 # these devices will then update to whatever commit is supplied as arg $1

--- a/update-test-group.sh
+++ b/update-test-group.sh
@@ -2,6 +2,8 @@
 # currently it will look for devices in an app that have an environment variable called "TEST"
 # these devices will then update to whatever commit is supplied as arg $1
 
+./check-configuration.sh || exit 1
+
 COMMIT_HASH=$1
 source ./resin.env
 


### PR DESCRIPTION
This solves issues like https://app.frontapp.com/open/cnv_nusrop, where the user appears to have incorrect configuration, but gets no clear feedback on that.

I've also added shebangs while I'm here, to force bash usage, because I'm using zsh and none of the commands are directly runnable otherwise.