### PR TITLE
Allow the unpinning of devices

### DIFF
--- a/set-device-to-a-build.sh
+++ b/set-device-to-a-build.sh
@@ -19,6 +19,10 @@ if ! [[ $DEVICE_ID =~ $IntRegex ]] && [[ $DEVICE_UUID =~ $IntRegex ]] ; then
 fi
 
 COMMIT=$2
-BUILD_ID=$(./get-build-id.sh $COMMIT)
+if [ -z $COMMIT ]; then
+	BUILD_ID="null"
+else
+	BUILD_ID=$(./get-build-id.sh $COMMIT)
+fi
 echo "setting device $DEVICE_ID to commit $COMMIT with buildID = $BUILD_ID"
 curl -X PATCH "https://api.$BASE_URL/v2/device($DEVICE_ID)" -H "Authorization: Bearer $authToken" -H "Content-Type: application/json" --data-binary '{"build":'$BUILD_ID'}'


### PR DESCRIPTION
Tested, and only providing a UUID will cause the device to be unpinned.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>